### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -32,5 +32,8 @@ jobs:
     - name: Check code formatting and lint
       run: make format-check
 
+    - name: Test building the package
+      run: make build
+
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/aismlv/minivan"
 keywords = ["nearest neighbor search"]
+packages = [
+    { include = "minivan"},
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"


### PR DESCRIPTION
* Allow building the package when the folder structure is different from `pypi` name
* Add building the package as a step to CI